### PR TITLE
Additional dependency for non-frontend envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Custom config
+results/
+trained_models/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For [OpenAI Baselines](https://github.com/openai/baselines), you'll need system 
 #### Ubuntu
 
 ```bash
-sudo apt-get update && sudo apt-get install cmake libopenmpi-dev python3-dev zlib1g-dev
+sudo apt-get update && sudo apt-get install cmake libopenmpi-dev python3-dev zlib1g-dev libgl1-mesa-glx
 ```
 
 #### Mac OS X


### PR DESCRIPTION
The system dependency added to README.md was missing when starting the repo in docker environment.

included a modified .gitignore file which prevents results and trained_models to be commited.