### PR TITLE
use "np.linalg.pinv()" instead of "np.linlang.inv()"

### DIFF
--- a/preprocessing/preprocessors.py
+++ b/preprocessing/preprocessors.py
@@ -133,7 +133,7 @@ def calcualte_turbulence(df):
         hist_price = df_price_pivot[[n in unique_date[0:i] for n in df_price_pivot.index ]]
         cov_temp = hist_price.cov()
         current_temp=(current_price - np.mean(hist_price,axis=0))
-        temp = current_temp.values.dot(np.linalg.inv(cov_temp)).dot(current_temp.values.T)
+        temp = current_temp.values.dot(np.linalg.pinv(cov_temp)).dot(current_temp.values.T)
         if temp>0:
             count+=1
             if count>2:


### PR DESCRIPTION
Replace the attached csv data (It's data from a foreign stock market) with "dow_30_2009_2020.csv" and remove "done_data.csv".
If you run "run_DRL.py" it will throw an exception.

In calculating turbulence it is better to use "np.linlang.pinv()".

If the determinant of the matrix is zero it will not have an inverse and "inv()" function will not work. This usually happens if your matrix is singular. But "pinv()" will. This is because pinv returns the inverse of your matrix when it is available and the pseudo inverse when it isn't.

For excample [this code](https://github.com/tzhangwps/Turbulence-and-Systemic-Risk/blob/master/src/calculate.py) uses pinv() instead of inv() and it doesn't return any exception with my csv data:

[combined_tse.csv.zip](https://github.com/AI4Finance-LLC/Deep-Reinforcement-Learning-for-Automated-Stock-Trading-Ensemble-Strategy-ICAIF-2020/files/6060729/combined_tse.csv.zip)

