### PR TITLE
Add optional Adanos sentiment features

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ where $\mathcal{S}$ denotes stock selection, $\mathcal{A}$ portfolio allocation,
 
 | Layer | Role | Components |
 |:------|:-----|:-----------|
-| **Data** | Unified market data pipeline | FMP, Yahoo Finance, WRDS; LLM sentiment preprocessing; SQLite cache |
+| **Data** | Unified market data pipeline | FMP, Yahoo Finance, WRDS; optional [Adanos market sentiment](docs/adanos_sentiment_features.md); LLM sentiment preprocessing; SQLite cache |
 | **Strategy** | Weight-centric signal generation | Stock selection, portfolio allocation, timing adjustment, risk overlay |
 | **Backtest** | Offline evaluation | `bt`-powered engine with multi-benchmark comparison and transaction costs |
 | **Execution** | Live/paper trading | Alpaca multi-account integration with pre-trade risk checks |

--- a/docs/adanos_sentiment_features.md
+++ b/docs/adanos_sentiment_features.md
@@ -1,0 +1,41 @@
+# Adanos Market Sentiment Features
+
+FinRL-X can optionally enrich offline US equity datasets with daily market
+sentiment from [Adanos](https://api.adanos.org/docs). The processor keeps API
+access outside strategy and environment steps, caches successful responses
+locally, and returns one row per ticker and UTC date.
+
+Set your Adanos key in the `ADANOS_API_KEY` environment variable and fetch only
+the sources needed by the experiment:
+
+```python
+from src.data.adanos_sentiment import AdanosSentimentProcessor
+
+processor = AdanosSentimentProcessor()
+features = processor.fetch_daily_features(
+    tickers=["AAPL", "MSFT", "NVDA"],
+    start_date="2026-07-01",
+    end_date="2026-07-30",
+    sources=("reddit", "x", "news", "polymarket"),
+)
+
+prices_with_sentiment = processor.merge_with_prices(price_data, features)
+```
+
+The returned columns are prefixed by source, for example
+`adanos_reddit_sentiment_score`, `adanos_news_buzz_score`, and
+`adanos_polymarket_activity_count`. Missing observations remain null rather
+than being converted to neutral sentiment or zero activity.
+
+Requests use inclusive `from` and `to` UTC dates. Choose a window supported by
+the API key's plan and the selected source. Completed UTC windows are cached as
+JSON under `data/cache/adanos` by default; windows that include the current UTC
+date are fetched again because their aggregates are still changing. Pass
+`force_refresh=True` to refresh a completed window. The API key is sent only in
+the `X-API-Key` request header and is never written to cache.
+
+Sentiment features are alternative research data, not trading recommendations.
+Daily aggregates cover their full UTC date. For decisions made before that date
+has ended, lag the features to the next eligible trading timestamp; the exact
+date join shown above does not enforce that causal delay. Preserve the dataset's
+existing train/test boundaries as well.

--- a/src/data/adanos_sentiment.py
+++ b/src/data/adanos_sentiment.py
@@ -1,0 +1,280 @@
+"""Optional Adanos market sentiment features for FinRL datasets."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Iterable, Mapping, Optional, Sequence
+
+import pandas as pd
+import requests
+
+SOURCE_ENDPOINTS = {
+    "reddit": "/reddit/stocks/v1/stock/{ticker}",
+    "x": "/x/stocks/v1/stock/{ticker}",
+    "news": "/news/stocks/v1/stock/{ticker}",
+    "polymarket": "/polymarket/stocks/v1/stock/{ticker}",
+}
+SOURCE_ACTIVITY_FIELDS = {
+    "reddit": "mentions",
+    "x": "mentions",
+    "news": "mentions",
+    "polymarket": "trade_count",
+}
+DAILY_METRICS = (
+    "sentiment_score",
+    "buzz_score",
+    "bullish_pct",
+    "bearish_pct",
+    "activity_count",
+)
+
+
+class AdanosSentimentProcessor:
+    """Fetch and prepare daily Adanos sentiment data for offline research."""
+
+    def __init__(
+        self,
+        base_url: str = "https://api.adanos.org",
+        cache_dir: str = "./data/cache/adanos",
+        timeout: int = 30,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        access_value = os.getenv("ADANOS_API_KEY")
+        if not access_value:
+            raise ValueError("Set ADANOS_API_KEY before using Adanos sentiment data.")
+
+        self.base_url = base_url.rstrip("/")
+        self.cache_dir = Path(cache_dir)
+        self.timeout = timeout
+        self.session = session or requests.Session()
+        self._request_headers = dict.fromkeys(("X-API-Key",), access_value)
+
+    def fetch_daily_features(
+        self,
+        tickers: Iterable[str],
+        start_date: str,
+        end_date: str,
+        sources: Sequence[str] = tuple(SOURCE_ENDPOINTS),
+        force_refresh: bool = False,
+    ) -> pd.DataFrame:
+        """Return one row per ticker and UTC date with source-prefixed features."""
+        start = self._parse_date(start_date, "start_date")
+        end = self._parse_date(end_date, "end_date")
+        if start > end:
+            raise ValueError("start_date must be on or before end_date")
+
+        normalized_tickers = self._normalize_tickers(tickers)
+        normalized_sources = self._normalize_sources(sources)
+        frames = []
+
+        for source in normalized_sources:
+            records = []
+            for ticker in normalized_tickers:
+                payload = self._get_payload(
+                    source, ticker, start, end, force_refresh=force_refresh
+                )
+                records.extend(self._daily_records(source, ticker, payload, start, end))
+
+            columns = ["tic", "datadate"] + self._feature_columns(source)
+            frame = pd.DataFrame.from_records(records, columns=columns)
+            if not frame.empty:
+                duplicates = frame.duplicated(["tic", "datadate"], keep=False)
+                if duplicates.any():
+                    raise ValueError(
+                        f"Adanos returned duplicate {source} observations for a ticker/date"
+                    )
+            frames.append(frame)
+
+        result = frames[0]
+        for frame in frames[1:]:
+            result = result.merge(
+                frame, on=["tic", "datadate"], how="outer", validate="one_to_one"
+            )
+
+        if result.empty:
+            return result
+        return result.sort_values(["tic", "datadate"]).reset_index(drop=True)
+
+    @staticmethod
+    def merge_with_prices(
+        price_data: pd.DataFrame,
+        sentiment_features: pd.DataFrame,
+        ticker_column: str = "tic",
+        date_column: str = "datadate",
+    ) -> pd.DataFrame:
+        """Left-join daily sentiment features without filling missing observations."""
+        required = {ticker_column, date_column}
+        missing_prices = required.difference(price_data.columns)
+        missing_features = required.difference(sentiment_features.columns)
+        if missing_prices:
+            raise ValueError(
+                f"price_data is missing required columns: {sorted(missing_prices)}"
+            )
+        if missing_features:
+            raise ValueError(
+                "sentiment_features is missing required columns: "
+                f"{sorted(missing_features)}"
+            )
+
+        prices = price_data.copy()
+        features = sentiment_features.copy()
+        for frame in (prices, features):
+            frame[ticker_column] = (
+                frame[ticker_column].astype(str).str.strip().str.lstrip("$").str.upper()
+            )
+            frame[date_column] = (
+                pd.to_datetime(frame[date_column], format="mixed", utc=True)
+                .dt.tz_localize(None)
+                .dt.normalize()
+            )
+
+        if features.duplicated([ticker_column, date_column]).any():
+            raise ValueError("sentiment_features must contain one row per ticker/date")
+
+        return prices.merge(
+            features,
+            on=[ticker_column, date_column],
+            how="left",
+            validate="many_to_one",
+        )
+
+    def _get_payload(
+        self,
+        source: str,
+        ticker: str,
+        start: date,
+        end: date,
+        force_refresh: bool,
+    ) -> Mapping[str, object]:
+        cache_path = self._cache_path(source, ticker, start, end)
+        cacheable = end < datetime.now(timezone.utc).date()
+        if cacheable and cache_path.exists() and not force_refresh:
+            with cache_path.open(encoding="utf-8") as cache_file:
+                payload = json.load(cache_file)
+            return self._validate_payload(payload)
+
+        endpoint = SOURCE_ENDPOINTS[source].format(ticker=ticker)
+        response = self.session.get(
+            f"{self.base_url}{endpoint}",
+            headers=self._request_headers,
+            params={"from": start.isoformat(), "to": end.isoformat()},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        payload = self._validate_payload(response.json())
+        if cacheable:
+            self._write_cache(cache_path, payload)
+        return payload
+
+    def _cache_path(self, source: str, ticker: str, start: date, end: date) -> Path:
+        request_identity = json.dumps(
+            {
+                "base_url": self.base_url,
+                "source": source,
+                "ticker": ticker,
+                "from": start.isoformat(),
+                "to": end.isoformat(),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        digest = hashlib.sha256(request_identity).hexdigest()[:16]
+        return self.cache_dir / f"{source}-{digest}.json"
+
+    def _write_cache(self, cache_path: Path, payload: Mapping[str, object]) -> None:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=cache_path.parent,
+                prefix=f".{cache_path.name}.",
+                delete=False,
+            ) as cache_file:
+                json.dump(payload, cache_file)
+                temporary_path = Path(cache_file.name)
+            temporary_path.replace(cache_path)
+        finally:
+            if temporary_path is not None and temporary_path.exists():
+                temporary_path.unlink()
+
+    @staticmethod
+    def _daily_records(
+        source: str,
+        ticker: str,
+        payload: Mapping[str, object],
+        start: date,
+        end: date,
+    ) -> list[dict[str, object]]:
+        daily_trend = payload.get("daily_trend") or []
+        if not isinstance(daily_trend, list):
+            raise ValueError("Adanos response field 'daily_trend' must be a list")
+
+        activity_field = SOURCE_ACTIVITY_FIELDS[source]
+        records = []
+        for item in daily_trend:
+            if not isinstance(item, Mapping):
+                raise ValueError("Adanos daily_trend items must be objects")
+            observation_date = AdanosSentimentProcessor._parse_date(
+                item.get("date"), "daily_trend.date"
+            )
+            if observation_date < start or observation_date > end:
+                continue
+            prefix = f"adanos_{source}_"
+            records.append(
+                {
+                    "tic": ticker,
+                    "datadate": pd.Timestamp(observation_date),
+                    f"{prefix}sentiment_score": item.get("sentiment_score"),
+                    f"{prefix}buzz_score": item.get("buzz_score"),
+                    f"{prefix}bullish_pct": item.get("bullish_pct"),
+                    f"{prefix}bearish_pct": item.get("bearish_pct"),
+                    f"{prefix}activity_count": item.get(activity_field),
+                }
+            )
+        return records
+
+    @staticmethod
+    def _parse_date(value: object, field_name: str) -> date:
+        if not isinstance(value, str):
+            raise ValueError(f"{field_name} must be a YYYY-MM-DD string")
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} must be a valid YYYY-MM-DD date") from exc
+
+    @staticmethod
+    def _normalize_tickers(tickers: Iterable[str]) -> list[str]:
+        normalized = []
+        for ticker in tickers:
+            value = str(ticker).strip().lstrip("$").upper()
+            if value and value not in normalized:
+                normalized.append(value)
+        if not normalized:
+            raise ValueError("At least one ticker is required")
+        return normalized
+
+    @staticmethod
+    def _normalize_sources(sources: Sequence[str]) -> list[str]:
+        normalized = [source.lower() for source in sources]
+        if not normalized:
+            raise ValueError("At least one Adanos source is required")
+        unsupported = set(normalized).difference(SOURCE_ENDPOINTS)
+        if unsupported:
+            raise ValueError(f"Unsupported Adanos sources: {sorted(unsupported)}")
+        return list(dict.fromkeys(normalized))
+
+    @staticmethod
+    def _feature_columns(source: str) -> list[str]:
+        return [f"adanos_{source}_{metric}" for metric in DAILY_METRICS]
+
+    @staticmethod
+    def _validate_payload(payload: object) -> Mapping[str, object]:
+        if not isinstance(payload, Mapping):
+            raise ValueError("Adanos response must be a JSON object")
+        return payload

--- a/tests/data/test_adanos_sentiment.py
+++ b/tests/data/test_adanos_sentiment.py
@@ -1,0 +1,198 @@
+import json
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+from src.data.adanos_sentiment import AdanosSentimentProcessor
+
+
+@pytest.fixture(autouse=True)
+def adanos_api_key(monkeypatch):
+    monkeypatch.setenv("ADANOS_API_KEY", "placeholder")
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, payloads):
+        self.payloads = iter(payloads)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return FakeResponse(next(self.payloads))
+
+
+def test_fetch_daily_features_uses_explicit_utc_window_and_pivots_sources(tmp_path):
+    session = FakeSession(
+        [
+            {
+                "ticker": "AAPL",
+                "daily_trend": [
+                    {
+                        "date": "2026-07-02",
+                        "mentions": 18,
+                        "sentiment_score": 0.4,
+                        "buzz_score": 52.5,
+                        "bullish_pct": 60,
+                        "bearish_pct": 20,
+                    },
+                    {
+                        "date": "2026-07-01",
+                        "mentions": 10,
+                        "sentiment_score": 0.2,
+                        "buzz_score": 40.0,
+                        "bullish_pct": 50,
+                        "bearish_pct": 10,
+                    },
+                ],
+            },
+            {
+                "ticker": "AAPL",
+                "daily_trend": [
+                    {
+                        "date": "2026-07-02",
+                        "trade_count": 7,
+                        "sentiment_score": -0.1,
+                        "buzz_score": 31.0,
+                        "bullish_pct": 30,
+                        "bearish_pct": 45,
+                    }
+                ],
+            },
+        ]
+    )
+    processor = AdanosSentimentProcessor(cache_dir=str(tmp_path), session=session)
+
+    result = processor.fetch_daily_features(
+        ["$aapl", "AAPL"],
+        "2026-07-01",
+        "2026-07-02",
+        sources=("reddit", "polymarket"),
+    )
+
+    assert list(result["tic"]) == ["AAPL", "AAPL"]
+    assert list(result["datadate"]) == [
+        pd.Timestamp("2026-07-01"),
+        pd.Timestamp("2026-07-02"),
+    ]
+    assert result.loc[1, "adanos_reddit_activity_count"] == 18
+    assert result.loc[1, "adanos_polymarket_activity_count"] == 7
+    assert pd.isna(result.loc[0, "adanos_polymarket_sentiment_score"])
+
+    assert len(session.calls) == 2
+    for _, kwargs in session.calls:
+        assert kwargs["headers"] == {"X-API-Key": "placeholder"}
+        assert kwargs["params"] == {"from": "2026-07-01", "to": "2026-07-02"}
+        assert "days" not in kwargs["params"]
+
+
+def test_fetch_daily_features_reuses_successful_cached_response(tmp_path):
+    payload = {
+        "ticker": "MSFT",
+        "daily_trend": [
+            {
+                "date": "2026-07-01",
+                "mentions": 4,
+                "sentiment_score": 0.1,
+                "buzz_score": 12.0,
+                "bullish_pct": 40,
+                "bearish_pct": 15,
+            }
+        ],
+    }
+    session = FakeSession([payload])
+    processor = AdanosSentimentProcessor(cache_dir=str(tmp_path), session=session)
+
+    first = processor.fetch_daily_features(
+        ["MSFT"], "2026-07-01", "2026-07-01", sources=("news",)
+    )
+    second = processor.fetch_daily_features(
+        ["MSFT"], "2026-07-01", "2026-07-01", sources=("news",)
+    )
+
+    pd.testing.assert_frame_equal(first, second)
+    assert len(session.calls) == 1
+    cache_files = list(tmp_path.glob("*.json"))
+    assert len(cache_files) == 1
+    assert "placeholder" not in cache_files[0].read_text()
+    assert json.loads(cache_files[0].read_text()) == payload
+
+
+def test_fetch_daily_features_does_not_cache_current_utc_day(tmp_path):
+    current_date = datetime.now(timezone.utc).date().isoformat()
+    payload = {
+        "ticker": "MSFT",
+        "daily_trend": [{"date": current_date, "mentions": 2}],
+    }
+    session = FakeSession([payload, payload])
+    processor = AdanosSentimentProcessor(cache_dir=str(tmp_path), session=session)
+
+    processor.fetch_daily_features(
+        ["MSFT"], current_date, current_date, sources=("reddit",)
+    )
+    processor.fetch_daily_features(
+        ["MSFT"], current_date, current_date, sources=("reddit",)
+    )
+
+    assert len(session.calls) == 2
+    assert list(tmp_path.glob("*.json")) == []
+
+
+def test_merge_with_prices_keeps_missing_sentiment_distinct_from_neutral():
+    prices = pd.DataFrame(
+        {
+            "tic": ["aapl", "AAPL"],
+            "datadate": ["2026-07-01T23:00:00-04:00", "2026-07-03"],
+            "adj_close": [200.0, 202.0],
+        }
+    )
+    features = pd.DataFrame(
+        {
+            "tic": ["AAPL"],
+            "datadate": [pd.Timestamp("2026-07-02")],
+            "adanos_news_sentiment_score": [0.0],
+        }
+    )
+
+    result = AdanosSentimentProcessor.merge_with_prices(prices, features)
+
+    assert result.loc[0, "datadate"] == pd.Timestamp("2026-07-02")
+    assert result.loc[0, "adanos_news_sentiment_score"] == 0.0
+    assert pd.isna(result.loc[1, "adanos_news_sentiment_score"])
+
+
+@pytest.mark.parametrize(
+    ("start_date", "end_date", "sources", "message"),
+    [
+        ("2026-07-02", "2026-07-01", ("reddit",), "start_date"),
+        ("not-a-date", "2026-07-01", ("reddit",), "valid YYYY-MM-DD"),
+        ("2026-07-01", "2026-07-02", ("unknown",), "Unsupported"),
+    ],
+)
+def test_fetch_daily_features_rejects_invalid_requests(
+    tmp_path, start_date, end_date, sources, message
+):
+    processor = AdanosSentimentProcessor(
+        cache_dir=str(tmp_path), session=FakeSession([])
+    )
+
+    with pytest.raises(ValueError, match=message):
+        processor.fetch_daily_features(["AAPL"], start_date, end_date, sources)
+
+
+def test_api_key_is_required(monkeypatch, tmp_path):
+    monkeypatch.delenv("ADANOS_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="ADANOS_API_KEY"):
+        AdanosSentimentProcessor(cache_dir=str(tmp_path))


### PR DESCRIPTION
## Summary

- add an opt-in `AdanosSentimentProcessor` for daily US equity sentiment from Reddit, X, news, and Polymarket
- normalize source responses into one row per ticker and UTC date with source-prefixed features
- cache only completed UTC windows and provide a validated left join for FinRL price datasets
- document setup, plan-aware date windows, missing-data semantics, and look-ahead precautions

## Design

The integration stays in the data layer and performs no API calls inside strategy, environment, backtest, or execution steps. It uses the existing `requests` dependency and `ADANOS_API_KEY`; no additional package is required. Requests use the current inclusive `from` / `to` API contract rather than the deprecated `days` parameter.

Successful historical responses are cached by a request fingerprint that excludes the API key. Windows including the current UTC date are deliberately re-fetched because their daily aggregates are incomplete and still changing.

## Verification

- `python -m pytest -q` (8 passed)
- `python -m black --check src/data/adanos_sentiment.py tests/data/test_adanos_sentiment.py`
- `python -m compileall -q src/data/adanos_sentiment.py tests/data/test_adanos_sentiment.py`
- `python -m pip check`
- current `https://api.adanos.org/openapi.json` checked for all four endpoint, date parameter, response schema, and activity-field contracts
- structured autoreview: clean, no accepted/actionable findings

Adanos API documentation: https://api.adanos.org/docs
